### PR TITLE
chore: change default domain from tinfoil.sh to tinfoil.dev

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	TLSEnv           string `yaml:"tls-env" default:"production"`       // production | staging
 	TLSChallengeMode string `yaml:"tls-challenge" default:"dns"`        // tls | dns | http
 	TLSWildcard      bool   `yaml:"tls-wildcard" default:"false"`       // include wildcard SAN (*.domain)
-	TLSOwnSANDomain  bool   `yaml:"tls-own-san-domain" default:"false"` // use own domain for encoded SANs instead of tinfoil.sh
+	TLSOwnSANDomain  bool   `yaml:"tls-own-san-domain" default:"false"` // use own domain for encoded SANs instead of tinfoil.dev
 
 	ControlPlane  string `yaml:"control-plane" default:"https://api.tinfoil.sh"`
 	Authenticated bool   `yaml:"authenticated" default:"false"`

--- a/main.go
+++ b/main.go
@@ -125,9 +125,9 @@ func main() {
 	baseDomain := externalConfig.Domain
 
 	// Domain used for encoded SANs (HPKE key, attestation).
-	// Defaults to tinfoil.sh (control plane manages DNS); set own-encoded-domain
+	// Defaults to tinfoil.dev (control plane manages DNS); set own-encoded-domain
 	// to use the base domain instead.
-	encodedSANDomain := "tinfoil.sh"
+	encodedSANDomain := "tinfoil.dev"
 	if config.TLSOwnSANDomain {
 		encodedSANDomain = baseDomain
 		if d, err := publicsuffix.EffectiveTLDPlusOne(baseDomain); err == nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Change default encoded SAN domain from tinfoil.sh to tinfoil.dev to align with the new root domain. This only affects the fallback domain used for HPKE key and attestation SANs; setups with tls-own-san-domain enabled are unaffected.

<sup>Written for commit 0b0a5d2ed3e147cf9cb4754ae4c329ad4e96f4c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

