### PR TITLE
chore: archive the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Tinfoil Attestation Shim
+# [ARCHIVED] Tinfoil Attestation Shim
+
+### This repository has been archived.
+
+**The shim has been merged into [cvmimage](https://github.com/tinfoilsh/cvmimage) at `tinfoil/cmd/shim/`.** All future development happens there.
+
+---
 
 A reverse proxy service that terminates TLS and exposes the attestation attestation report over HTTP.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Archived this repository and updated the README to point to the new home for the shim. The shim now lives in `cvmimage` at `tinfoil/cmd/shim`; all future work happens there.

- **Migration**
  - Use `cvmimage` at `tinfoil/cmd/shim` for builds, issues, and updates.
  - Update any links and references to the new location.

<sup>Written for commit a3fccdf73fffd42425801d360705bbd420455edf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

